### PR TITLE
Use nix package manager for dev environment & CI build

### DIFF
--- a/.github/workflows/continuous-deployment-to-github-pages.yml
+++ b/.github/workflows/continuous-deployment-to-github-pages.yml
@@ -2,39 +2,17 @@ name: Continuous Deployment to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - use-nix-experiment
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
 
-    container:
-      image: ruby:2.6.6
-
     steps:
       - name: Checkout repo
         uses: actions/checkout@master
-      - name: Update package lists
-        run: apt-get update -qq
-      - name: Install packages
-        run: apt-get -yqq install nodejs
-      - name: Install bundler
-        run: gem install bundler:2.1.4
-      - name: Setup bundler cache
-        uses: actions/cache@v2
+      - uses: cachix/install-nix-action@v10
         with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
-      - name: Install bundled gems
-        run: |
-          bundle config path vendor/bundle
-          bundle install --jobs 4 --retry 3
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Build site
-        run: bundle exec middleman build
-      - name: Publish site
-        uses: maxheld83/ghpages@v0.2.1
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
-          BUILD_DIR: ./build
+        run: nix-shell --command 'middleman build'

--- a/gemset.nix
+++ b/gemset.nix
@@ -1,0 +1,429 @@
+{
+  activesupport = {
+    dependencies = ["concurrent-ruby" "i18n" "minitest" "tzinfo"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "02fdawr3wyvpzpja3r7mvb8lmn2mm5jdw502bx3ncr2sy2nw1kx6";
+      type = "gem";
+    };
+    version = "5.2.4.3";
+  };
+  addressable = {
+    dependencies = ["public_suffix"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fvchp2rhp2rmigx7qglf69xvjqvzq7x0g49naliw29r2bz656sy";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  backports = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qagwshq7zyjgm6k53hbrf4gfrwn6qz5d6rrc83cl59q37v68zsc";
+      type = "gem";
+    };
+    version = "3.18.1";
+  };
+  coffee-script = {
+    dependencies = ["coffee-script-source" "execjs"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rc7scyk7mnpfxqv5yy4y5q1hx3i7q3ahplcp4bq2g5r24g2izl2";
+      type = "gem";
+    };
+    version = "2.4.1";
+  };
+  coffee-script-source = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1907v9q1zcqmmyqzhzych5l7qifgls2rlbnbhy5vzyr7i7yicaz1";
+      type = "gem";
+    };
+    version = "1.12.2";
+  };
+  concurrent-ruby = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "094387x4yasb797mv07cs3g6f08y56virc2rjcpb1k79rzaj3nhl";
+      type = "gem";
+    };
+    version = "1.1.6";
+  };
+  contracts = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jqn5pkjpag5fzx1z8s8y97d49pb58j5ng3pmbam4ynk6j6hr5f5";
+      type = "gem";
+    };
+    version = "0.13.0";
+  };
+  dotenv = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17hkd62ig9b0czv192kqdfq7gw0a8hgq07yclri6myc8y5lmfin5";
+      type = "gem";
+    };
+    version = "2.7.5";
+  };
+  erubis = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1fj827xqjs91yqsydf0zmfyw9p4l2jz5yikg3mppz6d7fi8kyrb3";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  execjs = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1yz55sf2nd3l666ms6xr18sm2aggcvmb8qr3v53lr4rir32y1yp1";
+      type = "gem";
+    };
+    version = "2.7.0";
+  };
+  fast_blank = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16s1ilyvwzmkcgmklbrn0c2pch5n02vf921njx0bld4crgdr6z56";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  fastimage = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "06lgsy1zdkhhgd9w1c0nb7v9d38mljwz13n6gi3acbzkhz1sf642";
+      type = "gem";
+    };
+    version = "2.1.7";
+  };
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "12lpwaw82bb0rm9f52v1498bpba8aj2l2q359mkwbxsswhpga5af";
+      type = "gem";
+    };
+    version = "1.13.1";
+  };
+  haml = {
+    dependencies = ["temple" "tilt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0dwarfbc04bblljs4xg9fy57b5y8xrck6slhssa6bd7x58bh222c";
+      type = "gem";
+    };
+    version = "5.1.2";
+  };
+  hamster = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n1lsh96vnyc1pnzyd30f9prcsclmvmkdb3nm5aahnyizyiy6lar";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+  hashie = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "13bdzfp25c8k51ayzxqkbzag3wj5gc1jd8h7d985nsq6pn57g5xh";
+      type = "gem";
+    };
+    version = "3.6.0";
+  };
+  i18n = {
+    dependencies = ["concurrent-ruby"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "038qvz7kd3cfxk8bvagqhakx68pfbnmghpdkx7573wbf0maqp9a3";
+      type = "gem";
+    };
+    version = "0.9.5";
+  };
+  kramdown = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1n1c4jmrh5ig8iv1rw81s4mw4xsp4v97hvf8zkigv4hn5h542qjq";
+      type = "gem";
+    };
+    version = "1.17.0";
+  };
+  listen = {
+    dependencies = ["rb-fsevent" "rb-inotify"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1l0y7hbyfiwpvk172r28hsdqsifq1ls39hsfmzi1vy4ll0smd14i";
+      type = "gem";
+    };
+    version = "3.0.8";
+  };
+  memoist = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0i9wpzix3sjhf6d9zw60dm4371iq8kyz7ckh2qapan2vyaim6b55";
+      type = "gem";
+    };
+    version = "0.16.2";
+  };
+  middleman = {
+    dependencies = ["coffee-script" "haml" "kramdown" "middleman-cli" "middleman-core"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1zs8434q5xww95q8az17c749hcf2lw4a2744w0ny7c32v65a6f3c";
+      type = "gem";
+    };
+    version = "4.3.7";
+  };
+  middleman-blog = {
+    dependencies = ["addressable" "middleman-core" "tzinfo"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "069xj3mzm1vw984mx9fxxcm2q9xprqbczwfc6h21nnq7bbk4691p";
+      type = "gem";
+    };
+    version = "4.0.1";
+  };
+  middleman-cli = {
+    dependencies = ["thor"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0clpbdb7p620dl33cys570ar73r9kvi0j62qq45a74y7jixsldnl";
+      type = "gem";
+    };
+    version = "4.3.7";
+  };
+  middleman-core = {
+    dependencies = ["activesupport" "addressable" "backports" "contracts" "dotenv" "erubis" "execjs" "fast_blank" "fastimage" "hamster" "hashie" "i18n" "listen" "memoist" "padrino-helpers" "parallel" "rack" "sassc" "servolux" "tilt" "uglifier"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jdw2bas81j7ayilbx5pinipvkndh3j8l96jhnia2bg5lnic9dv1";
+      type = "gem";
+    };
+    version = "4.3.7";
+  };
+  minitest = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09bz9nsznxgaf06cx3b5z71glgl0hdw469gqx3w7bqijgrb55p5g";
+      type = "gem";
+    };
+    version = "5.14.1";
+  };
+  padrino-helpers = {
+    dependencies = ["i18n" "padrino-support" "tilt"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "03n8iyr8bhipf13fqx6dlr4ddvcgcksyx9l9w18ph8921hvl1vgf";
+      type = "gem";
+    };
+    version = "0.13.3.4";
+  };
+  padrino-support = {
+    dependencies = ["activesupport"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0r7mvfvwckyjbydmlb7bmajn1ds02856gp690m95adg9hdp418vk";
+      type = "gem";
+    };
+    version = "0.13.3.4";
+  };
+  parallel = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "17b127xxmm2yqdz146qwbs57046kn0js1h8synv01dwqz2z1kp2l";
+      type = "gem";
+    };
+    version = "1.19.2";
+  };
+  public_suffix = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0vywld400fzi17cszwrchrzcqys4qm6sshbv73wy5mwcixmrgg7g";
+      type = "gem";
+    };
+    version = "4.0.5";
+  };
+  rack = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0i5vs0dph9i5jn8dfc6aqd6njcafmb20rwqngrf759c9cvmyff16";
+      type = "gem";
+    };
+    version = "2.2.3";
+  };
+  rb-fsevent = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k9bsj7ni0g2fd7scyyy1sk9dy2pg9akniahab0iznvjmhn54h87";
+      type = "gem";
+    };
+    version = "0.10.4";
+  };
+  rb-inotify = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1jm76h8f8hji38z3ggf4bzi8vps6p7sagxn3ab57qc0xyga64005";
+      type = "gem";
+    };
+    version = "0.10.1";
+  };
+  RedCloth = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0m9dv7ya9q93r8x1pg2gi15rxlbck8m178j1fz7r5v6wr1avrrqy";
+      type = "gem";
+    };
+    version = "4.3.2";
+  };
+  sassc = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gpqv48xhl8mb8qqhcifcp0pixn206a7imc07g48armklfqa4q2c";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  servolux = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "068mjsim0259122rizmkh54d1yjwdsnx66cvk251s1pqb1ac8cqs";
+      type = "gem";
+    };
+    version = "0.13.0";
+  };
+  temple = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "060zzj7c2kicdfk6cpnn40n9yjnhfrr13d0rsbdhdij68chp2861";
+      type = "gem";
+    };
+    version = "0.8.2";
+  };
+  thor = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xbhkmyhlxwzshaqa7swy2bx6vd64mm0wrr8g3jywvxy7hg0cwkm";
+      type = "gem";
+    };
+    version = "1.0.1";
+  };
+  thread_safe = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nmhcgq6cgz44srylra07bmaw99f5271l0dpsvl5f75m44l0gmwy";
+      type = "gem";
+    };
+    version = "0.3.6";
+  };
+  tilt = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rn8z8hda4h41a64l0zhkiwz2vxw9b1nb70gl37h1dg2k874yrlv";
+      type = "gem";
+    };
+    version = "2.0.10";
+  };
+  tzinfo = {
+    dependencies = ["thread_safe"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1i3jh086w1kbdj3k5l60lc3nwbanmzdf8yjj3mlrx9b2gjjxhi9r";
+      type = "gem";
+    };
+    version = "1.2.7";
+  };
+  uglifier = {
+    dependencies = ["execjs"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0wmqvn4xncw6h3d5gp2a44170zwxfyj3iq4rsjp16zarvzbdmgnz";
+      type = "gem";
+    };
+    version = "3.2.0";
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,12 @@
+with (import <nixpkgs> {});
+let
+  ruby = ruby_2_6;
+  env = bundlerEnv {
+    name = "jamesmead.org-bundler-env";
+    inherit ruby;
+    gemdir = ./.;
+  };
+in stdenv.mkDerivation {
+  name = "jamesmead.org";
+  buildInputs = [ env ruby nodejs ];
+}


### PR DESCRIPTION
* `gemset.nix` was generated by running `bundix` against `Gemfile.lock`.

* outline of `shell.nix` was generated by using `--init` option when running
`bundix`; however I also added 'ruby' to the buildInputs list to ensure
the right version of ruby is used within the nix shell.

* ~I haven't included `node.js` yet, because it doesn't actually seem to be
needed even though the `coffee-script` & `uglifier` gem supposedly need it.~

* I've had to upgrade the app to the latest Ruby v2.6 patch version and
upgrade bundler to match the bundler installed in that version; 
`shell.nix` does specify Ruby v2.6, but not the patch version or the 
version of bundler.

* I've changed the branch for the GitHub action workflow from `master` -> `use-nix-experiment` and deliberately removed the step which published the site so I can test the workflow. If this PR was ever to be merged, these issues would need to be resolved.

### To do

* [ ] Maybe build `gemset.nix` on demand and don't include in the git repo?
* [ ] Somehow specify the bundler version
* [ ] Do we need to specify the version of nixpkgs or anything else to ensure complete reproducability?
* [ ] Add nix root (?) to protect against garbage collection while `nix-shell` is running?